### PR TITLE
MicroCMSのAPIから記事を取得・大まかなレイアウト配置の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.1.0",
       "dependencies": {
+        "cheerio": "^1.0.0-rc.12",
         "html-react-parser": "^4.2.2",
         "microcms-js-sdk": "^2.6.1",
         "next": "latest",
@@ -886,6 +887,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1016,6 +1022,60 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -1113,6 +1173,32 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -3151,6 +3237,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3343,6 +3440,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "dependencies": {
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "cheerio": "^1.0.0-rc.12",
     "html-react-parser": "^4.2.2",
     "microcms-js-sdk": "^2.6.1",
     "next": "latest",

--- a/src/app/articles/[postId]/page.tsx
+++ b/src/app/articles/[postId]/page.tsx
@@ -1,0 +1,39 @@
+import { notFound } from "next/navigation";
+import parse from "html-react-parser";
+import { getDetail, getList } from "../../../../libs/microcms";
+
+export async function generateStaticParams() {
+  const { contents } = await getList();
+
+  const paths = contents.map((post) => {
+    return {
+      postId: post.id,
+    };
+  });
+
+  return [...paths];
+}
+
+export default async function StaticDetailPage({
+  params: { postId },
+}: {
+  params: { postId: string };
+}) {
+  const post = await getDetail(postId);
+  console.log(post);
+
+  // ページの生成された時間を取得
+  const time = new Date().toLocaleString();
+
+  if (!post) {
+    notFound();
+  }
+
+  return (
+    <div className="lg:col-span-2">
+      <div className="markdown">
+        <div>{parse(post.content)}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,28 +1,6 @@
 import Link from "next/link";
 import { getList } from "../../../libs/microcms";
 
-export default async function StaticPage() {
-  const { contents } = await getList();
-
-  // ページの生成された時間を取得
-  const time = new Date().toLocaleString();
-
-  if (!contents || contents.length === 0) {
-    return <h1>No contents</h1>;
-  }
-
-  return (
-    <div>
-      <h1>{time}</h1>
-      <ul>
-        {contents.map((post) => {
-          return (
-            <li key={post.id}>
-              <Link href={`/static/${post.id}`}>{post.title}</Link>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
+export default function Home() {
+  return <div>aaa</div>;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,216 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.markdown h1 {
+  margin-top: 50px;
+  font-size: 1.9rem;
+  font-weight: bold;
+  margin-bottom: 3rem;
+  color: #2c3e50; /* Maintaining the sophisticated look */
+}
+
+.markdown h2 {
+  margin-top: 30px;
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  border-left: 5px solid #3498db; /* Vibrant blue border */
+  padding-left: 0.5rem;
+  color: #2c3e50; /* Matching color */
+  background-color: #ffffff; /* Subtle grey background */
+}
+
+.markdown h3 {
+  font-weight: bold;
+  text-decoration: underline;
+  margin-top: 20px;
+  font-size: 1.3rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: #2c3e50; /* Matching color */
+}
+
+.markdown h4 {
+  font-weight: bold;
+  font-size: 1.1rem;
+  margin-top: 1.2rem;
+  margin-bottom: 0.3rem;
+  color: #2c3e50; /* Matching color */
+}
+
+.markdown ul {
+  list-style-type: disc;
+  margin-left: 2rem;
+  padding-left: 10px;
+}
+
+.markdown li {
+  font-weight: bold;
+  padding: 3px;
+}
+
+.markdown ol {
+  list-style-type: decimal;
+  margin-left: 2rem;
+}
+
+.markdown a {
+  color: #3498db; /* Blue link color */
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.markdown a:hover {
+  color: #2980b9; /* Slightly darker blue on hover */
+  text-decoration: underline;
+}
+
+.markdown pre {
+  background-color: #2c3e50; /* Darker grey background */
+  padding: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 0.1rem;
+  border-radius: 5px;
+  overflow-x: auto;
+  color: #ecf0f1; /* Light text color */
+  margin-bottom: 30px;
+  margin-top: 30px;
+}
+
+.markdown pre > code {
+  background-color: #2c3e50;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: "Fira Code", monospace; /* Monospace font for code */
+  color: #ecf0f1; /* Light text color */
+}
+
+.markdown div {
+  position: relative;
+}
+
+.markdown code {
+  background-color: #eaecee;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: "Fira Code", monospace; /* Monospace font for code */
+  color: #c0392b; /* Red text color */
+}
+
+.markdown div div[data-filename]::before {
+  content: attr(data-filename); /* data-filename属性の値を表示 */
+  color: #2c3e50; /* Matching text color */
+  background-color: #ecf0f1; /* Subtle grey background */
+  padding: 0.25rem 0.5rem;
+  border-top-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+  font-size: 0.75rem;
+  font-weight: bold;
+  position: absolute;
+}
+
+.markdown blockquote {
+  border-left: 5px solid #3498db; /* Matching blue border */
+  padding-left: 1rem;
+  margin: 10px;
+  margin-left: 2rem;
+  color: #7f8c8d; /* Slightly darker grey text color */
+  font-style: italic;
+}
+
+.markdown hr {
+  border: none;
+  border-top: 2px solid #ecf0f1; /* Light grey border */
+  margin: 1.5rem 0;
+}
+
+.markdown img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 1.5rem auto;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* Light shadow */
+}
+
+.markdown p {
+  padding-left: 10px;
+}
+
+@media (max-width: 768px) {
+  .markdown h1 {
+    font-size: 1.3rem;
+  }
+
+  .markdown h2 {
+    font-size: 1.1rem;
+  }
+
+  .markdown h3 {
+    font-size: 0.9rem;
+  }
+
+  .markdown h4 {
+    font-size: 0.8rem;
+  }
+
+  .markdown ul {
+    margin-left: 1rem;
+  }
+
+  .markdown ol {
+    margin-left: 1rem;
+  }
+
+  .markdown pre {
+    font-size: 0.9rem;
+  }
+
+  .markdown code {
+    font-size: 0.9rem;
+  }
+
+  .markdown blockquote {
+    font-size: 1rem;
+  }
+}
+
+.timeline {
+  list-style: none;
+}
+.timeline > li {
+  margin-bottom: 60px;
+}
+
+/* for Desktop */
+@media (min-width: 640px) {
+  .timeline > li {
+    overflow: hidden;
+    margin: 0;
+    position: relative;
+  }
+  .timeline-date {
+    width: 110px;
+    float: left;
+    margin-top: 20px;
+  }
+  .timeline-content {
+    width: 75%;
+    float: left;
+    border-left: 3px #e5e5d1 solid;
+    padding-left: 30px;
+    padding-top: 20px;
+  }
+  .timeline-content:before {
+    content: "";
+    width: 12px;
+    height: 12px;
+    background: #837ccf;
+    position: absolute;
+    left: 106px;
+    top: 24px;
+    border-radius: 100%;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { getList } from "../../libs/microcms";
 
 export default async function Page() {
   const { contents } = await getList();
+
   console.log(contents);
 
   if (!contents || contents.length === 0) {
@@ -26,8 +27,8 @@ export default async function Page() {
           {contents.map((post) => {
             return (
               // eslint-disable-next-line react/jsx-key
-              <div>
-                <Link href={"/articles"}>
+              <div key={post.id}>
+                <Link href={`/articles/${post.id}`}>
                   <div className="flex-shrink-0">
                     <img
                       className="object-cover w-full h-48"
@@ -38,7 +39,7 @@ export default async function Page() {
                 </Link>
                 <div className="flex flex-col justify-between flex-1 p-6 bg-white">
                   <div className="flex-1">
-                    <Link href={"/articles"}>
+                    <Link href={`/articles/${post.id}`}>
                       <p className="text-xl font-semibold text-neutral-600">
                         {post.title}
                       </p>


### PR DESCRIPTION
content部分はglobals.cssのTailwindCSSが邪魔するので、別途CSSを適用させて上書きさせる方式を採用

```css:globalls.css
ex)
.markdown h1 {
  margin-top: 50px;
  font-size: 1.9rem;
  font-weight: bold;
  margin-bottom: 3rem;
  color: #2c3e50; /* Maintaining the sophisticated look */
}
```